### PR TITLE
Avoid crashing on 'misc.' and other irregular words

### DIFF
--- a/lib/underscore.inflections.js
+++ b/lib/underscore.inflections.js
@@ -152,20 +152,25 @@
     };
 
     Inflections.prototype.apply_inflections = function(word, rules) {
-      var capture, regex, result, rule, _i, _len;
-      result = word;
-      if (!word || _.indexOf(this.uncountables, result.toLowerCase().match(/\b\w+$/)[0]) !== -1) {
-        return result;
+      var capture, match, regex, result, rule, _i, _len;
+      if (!word) {
+        return word;
       } else {
-        for (_i = 0, _len = rules.length; _i < _len; _i++) {
-          rule = rules[_i];
-          regex = rule[0], capture = rule[1];
-          if (result.match(regex)) {
-            result = result.replace(regex, capture);
-            break;
+        result = word;
+        match = result.toLowerCase().match(/\b\w+$/);
+        if (match && _.indexOf(this.uncountables, match[0]) !== -1) {
+          return result;
+        } else {
+          for (_i = 0, _len = rules.length; _i < _len; _i++) {
+            rule = rules[_i];
+            regex = rule[0], capture = rule[1];
+            if (result.match(regex)) {
+              result = result.replace(regex, capture);
+              break;
+            }
           }
+          return result;
         }
-        return result;
       }
     };
 

--- a/src/underscore.inflections.coffee
+++ b/src/underscore.inflections.coffee
@@ -190,17 +190,20 @@ class Inflections
   # Apple rules to a given word. If the last word fo the string is uncountable,
   # just return it. Otherwise, make the replacement and return that.
   apply_inflections: (word, rules) =>
-    result = word
-
-    if !word or _.indexOf(@uncountables, result.toLowerCase().match(/\b\w+$/)[0]) isnt -1
-      result
+    if (!word)
+      return word
     else
-      for rule in rules
-        [regex, capture] = rule
-        if result.match regex
-          result = result.replace regex, capture
-          break
-      result
+      result = word
+      match = result.toLowerCase().match(/\b\w+$/)
+      if match and _.indexOf(@uncountables, match[0]) isnt -1
+        result
+      else
+        for rule in rules
+          [regex, capture] = rule
+          if result.match regex
+            result = result.replace regex, capture
+            break
+        result
 
 # Export to window or exports
 root = exports ? @

--- a/test/inflections_test.coffee
+++ b/test/inflections_test.coffee
@@ -121,6 +121,7 @@ irregularities =
   'child'  : 'children',
   'sex'    : 'sexes',
   'move'   : 'moves',
+  'misc.'  : 'misc.',
 
 describe 'underscore.inflections', ->
   describe 'singularize', ->

--- a/test/inflections_test.js
+++ b/test/inflections_test.js
@@ -101,7 +101,8 @@
     'man': 'men',
     'child': 'children',
     'sex': 'sexes',
-    'move': 'moves'
+    'move': 'moves',
+    'misc.': 'misc.'
   };
 
   describe('underscore.inflections', function() {


### PR DESCRIPTION
When attempting to singularize 'misc.' underscore.inflections throws the following exception:

```
TypeError: Cannot read property '0' of null
    at Inflections.apply_inflections (file://localhost/Users/hugues/proj/stoic-umbrella/underscore.inflections/lib/underscore.inflections.js:157:85)
    at Inflections.apply_inflections (file://localhost/Users/hugues/proj/stoic-umbrella/underscore.inflections/lib/underscore.inflections.js:4:61)
    at Inflections.singularize (file://localhost/Users/hugues/proj/stoic-umbrella/underscore.inflections/lib/underscore.inflections.js:151:19)
    at Function.singularize (file://localhost/Users/hugues/proj/stoic-umbrella/underscore.inflections/lib/underscore.inflections.js:4:61)
    at Context.<anonymous> (file://localhost/Users/hugues/proj/stoic-umbrella/underscore.inflections/test/inflections_test.js:222:13)
```

Here is the suggested fix.

I hope this helps and thanks for maintaining this library!
