### PR TITLE
Tracking higher versions of underscore(.string)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "url": "http://github.com/geetarista/underscore.inflections.git"
   },
   "dependencies": {
-    "underscore": "~1.3",
-    "underscore.string": "~2.3.0"
+    "underscore": "~1.x",
+    "underscore.string": "~2.3.x"
   },
   "devDependencies": {
     "chai": "~1.0",


### PR DESCRIPTION
User Higher version of Underscore and underscore.string if available.

A lot of projects depend on higher versions of underscore and currently 1.5.1 is available.
Please feel free to change the versions to make it use stricter underscore tracking instead of 1.x
